### PR TITLE
add release github workflow for building "official" plugin suitable for terraform registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,172 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  test:  # this is cloned from ci.yml until github actions support job reuse
+    if: ${{ github.repository_owner == 'terraform-provider-concourse' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        concourse-version:
+          - "6.5.1"
+          - "6.7.0"
+    steps:
+      - name: setup
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: ensure-containers-exist
+        env:
+          CONCOURSE_VERSION: ${{ matrix.concourse-version }}
+        run: |
+          docker-compose up -d && docker-compose down
+
+      - name: integration-tests
+        run: sudo make integration-tests
+
+  get-tag-name:
+    runs-on: ubuntu-latest
+    steps:
+      - id: get-tag-name-step
+        run: echo "::set-output name=tag_name::${GITHUB_REF/refs\/tags\//}"
+    outputs:
+      tag_name: ${{ steps.get-tag-name-step.outputs.tag_name }}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [ "test", "get-tag-name" ]
+    strategy:
+      matrix:
+        goos: [ "linux", "darwin" ]
+    steps:
+      - name: setup
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: compile
+        id: compile
+        env:
+          BINARY_NAME: terraform-provider-concourse_${{ needs.get-tag-name.outputs.tag_name }}
+          ZIP_NAME: terraform-provider-concourse_${{ needs.get-tag-name.outputs.tag_name }}_${{ matrix.goos }}_amd64.zip
+        run: |
+          GOOS="${{ matrix.goos }}" make
+          mv terraform-provider-concourse $BINARY_NAME
+          zip $ZIP_NAME $BINARY_NAME
+          echo "::set-output name=zip_name::$ZIP_NAME"
+
+      - id: upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.compile.outputs.zip_name }}
+          path: ./${{ steps.compile.outputs.zip_name }}
+
+  sign:
+    runs-on: ubuntu-latest
+    needs: [ "build", "get-tag-name" ]
+    steps:
+      - name: import-gpg-key
+        id: import-gpg-key
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_SECRET_KEY_PASSPHRASE }}
+      - name: download-artifacts
+        id: download-artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts/
+      - name: gather-hash-sign
+        id: gather-hash-sign
+        env:
+          HASH_FILE_NAME: terraform-provider-concourse_${{ needs.get-tag-name.outputs.tag_name }}_SHA256SUMS
+        run: |
+          mkdir gathered
+          cp artifacts/*.zip/*.zip gathered/
+          pushd gathered
+          sha256sum *.zip > $HASH_FILE_NAME
+          gpg --batch --local-user 95B055A2D6FF56B5D8A57849BDD24EEBEE0F9AE8 --detach-sign $HASH_FILE_NAME
+          popd
+          find gathered/ -type f -printf '%f\n' | jq --raw-input -c --slurp '.[:-1] | split("\n")' > all_artifacts.json
+          echo "::set-output name=hash_file_name::$HASH_FILE_NAME"
+          echo -n "::set-output name=all_artifacts_json::"
+          cat all_artifacts.json
+      - name: upload-hash-file-artifact
+        id: upload-hash-file-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.gather-hash-sign.outputs.hash_file_name }}
+          path: ./gathered/${{ steps.gather-hash-sign.outputs.hash_file_name }}
+      - name: upload-signature-artifact
+        id: upload-signature-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.gather-hash-sign.outputs.hash_file_name }}.sig
+          path: ./gathered/${{ steps.gather-hash-sign.outputs.hash_file_name }}.sig
+    outputs:
+      all_artifacts_json: ${{ steps.gather-hash-sign.outputs.all_artifacts_json }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: create-release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: A dummy release
+          draft: true
+    outputs:
+      release_upload_url: ${{ steps.create-release.outputs.upload_url }}
+
+  upload-release-assets:
+    runs-on: ubuntu-latest
+    needs: [ "create-release", "sign" ]
+    strategy:
+      matrix:
+        artifact: ${{ fromJson(needs.sign.outputs.all_artifacts_json) }}
+    steps:
+      - name: download-artifact
+        id: download-artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact }}
+
+      - name: determine-content-type
+        id: determine-content-type
+        env:
+          ARTIFACT_NAME: ${{ matrix.artifact }}
+        run: |
+          echo -n '::set-output name=content_type::'
+          if [[ ${ARTIFACT_NAME##*.} = 'zip' ]] ; then
+            echo 'application/zip'
+          elif [[ ${ARTIFACT_NAME##*.} = 'sig' ]] ; then
+            echo 'application/pgp-signature'
+          else
+            echo 'text/plain'
+          fi
+          
+      - name: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.release_upload_url }}
+          asset_path: ./${{ matrix.artifact }}
+          asset_name: ${{ matrix.artifact }}
+          asset_content_type: ${{ steps.determine-content-type.outputs.content_type }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ GENERATE_KEY := \
 		concourse/concourse:6.5 \
 		generate-key
 
+# shouldn't use CGO on binaries produced for the terraform registry
+export CGO_ENABLED=0
+
 .PHONY: build
 build: clean terraform-provider-concourse
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,146 @@
+# Concourse Provider
+
+A terraform provider for concourse
+
+## Why
+
+`fly` is an amazing tool, but configuration using scripts running fly is not
+ideal.
+
+## Example Usage
+
+### Create a provider (using target from fly)
+
+```hcl
+provider "concourse" {
+  target = "target_name"
+}
+```
+
+### Create a provider (using a local username and password)
+
+Note: this is not basic authentication
+
+```hcl
+provider "concourse" {
+  url  = "https://wings.pivotal.io"
+  team = "main"
+
+  username = "localuser"
+  password = "very-secure-password"
+}
+```
+
+### Look up a team
+
+```hcl
+data "concourse_team" "my_team" {
+  team_name = "main"
+}
+
+output "my_team_name" {
+  value = "${data.concourse_team.my_team.team_name}"
+}
+
+output "my_team_owners" {
+  value = "${data.concourse_team.my_team.owners}"
+}
+
+output "my_team_members" {
+  value = "${data.concourse_team.my_team.members}"
+}
+
+output "my_team_pipeline_operators" {
+  value = "${data.concourse_team.my_team.pipeline_operators}"
+}
+
+output "my_team_viewers" {
+  value = "${data.concourse_team.my_team.viewers}"
+}
+```
+
+### Look up a pipeline
+
+```hcl
+data "concourse_pipeline" "my_pipeline" {
+  team_name     = "main"
+  pipeline_name = "pipeline"
+}
+
+output "my_pipeline_team_name" {
+  value = "${data.concourse_pipeline.my_pipeline.team_name}"
+}
+
+output "my_pipeline_pipeline_name" {
+  value = "${data.concourse_pipeline.my_pipeline.pipeline_name}"
+}
+
+output "my_pipeline_is_exposed" {
+  value = "${data.concourse_pipeline.my_pipeline.is_exposed}"
+}
+
+output "my_pipeline_is_paused" {
+  value = "${data.concourse_pipeline.my_pipeline.is_paused}"
+}
+
+output "my_pipeline_json" {
+  value = "${data.concourse_pipeline.my_pipeline.json}"
+}
+
+output "my_pipeline_yaml" {
+  value = "${data.concourse_pipeline.my_pipeline.yaml}"
+}
+```
+
+### Create a team
+
+Supports `owners`, `members`, `pipeline_operators`, and `viewers`.
+
+Specify users and groups by prefixing the strings:
+
+* `user:`
+* `group:`
+
+```hcl
+resource "concourse_team" "my_team" {
+  team_name = "my-team"
+
+  owners = [
+    "group:github:org-name",
+    "group:github:org-name:team-name",
+    "user:github:tlwr",
+  ]
+
+  viewers = [
+    "user:github:samrees"
+  ]
+}
+```
+
+### Create a pipeline
+
+```hcl
+resource "concourse_pipeline" "my_pipeline" {
+  team_name     = "main"
+  pipeline_name = "my-pipeline"
+
+  is_exposed = true
+  is_paused  = true
+
+  pipeline_config        = "${file("pipeline-config.yml")}"
+  pipeline_config_format = "yaml"
+}
+
+# OR
+
+resource "concourse_pipeline" "my_pipeline" {
+  team_name     = "main"
+  pipeline_name = "my-pipeline"
+
+  is_exposed = true
+  is_paused  = true
+
+  pipeline_config        = "${file("pipeline-config.json")}"
+  pipeline_config_format = "json"
+}
+```


### PR DESCRIPTION
First part of https://trello.com/c/T3Oc4oce

Try to keep build process similar to our existing "known good" build process in `ci.yml` rather than following hashicorp's recommendation to use `goreleaser` and add yet another funny-tool-that-needs-configuration to our melange, which might build things in an ever so slightly different way from what we actually test.

This produces files according to the stipulations in https://www.terraform.io/docs/registry/providers/publishing.html#manually-preparing-a-release and adds them to a release (which it leaves in draft). You can see a number of these have already been created in draft state. I'll delete them at some point.

~Trigger on `u*` tags for now rather than `v*` so it's clear these aren't real releases. Probably switch that before merge.~

The current gpg key I've uploaded is a dummy.

I've had to copy-pasta the contents of `ci.yml` here to replicate it, but wonder if I should actually combine the two workflows into one, with all of the release-related stuff behind a tag-checking condition. Thoughts?