### PR TITLE
add sync-release-repo github workflow

### DIFF
--- a/.github/workflows/sync-release-repo.yml
+++ b/.github/workflows/sync-release-repo.yml
@@ -1,0 +1,20 @@
+name: sync-release-repo
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - master
+jobs:
+  repo-sync:
+    if: ${{ github.repository_owner == 'alphagov' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: repo-sync
+      uses: wei/git-sync@v2
+      with:
+        source_repo: "https://github.com/${{ github.repository }}.git"
+        source_branch: ${{ github.ref }}
+        destination_repo: "git@github.com:terraform-provider-concourse/terraform-provider-concourse.git"
+        destination_branch: ${{ github.ref }}
+        ssh_private_key: ${{ secrets.RELEASE_REPO_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
https://trello.com/c/T3Oc4oce

This also seems to work. Triggering on `v*` tags (well actually `u*` for now for the same reasons as in #16) and the `master` branch, will sync whatever current ref has triggered the run.

I should modify #16 before merge too to inhibit it running from `alphagov`.