### PR TITLE
added ca_cert_file and insecure_skip_verify in https connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ provider "concourse" {
 
   username = "localuser"
   password = "very-secure-password"
+  ca_cert_file = "path-to-ca-file"
+  insecure_skip_verify = false
 }
 ```
 

--- a/pkg/provider/config.go
+++ b/pkg/provider/config.go
@@ -36,12 +36,17 @@ func ProviderConfigurationBuilder(
 	team := d.Get("team").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
+	caFile := d.Get("ca_cert_file").(string)
+	skipCertificateVerification := d.Get("insecure_skip_verify").(bool)
 
 	if url != "" && team != "" && username != "" && password != "" {
 		c, err := client.NewConcourseClient(
 			url,
 			team,
-			username, password,
+			username,
+			password,
+			caFile,
+			skipCertificateVerification,
 		)
 
 		if err != nil {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,6 +19,17 @@ func Provider() *schema.Provider {
 				Description: "URL, do not use if using target ",
 				Optional:    true,
 			},
+			"ca_cert_file": {
+				Type:        schema.TypeString,
+				DefaultFunc: schema.EnvDefaultFunc("REQUESTS_CA_BUNDLE", nil),
+				Description: "Client CA certificates that are used while connecting to concourse",
+				Optional:    true,
+			},
+			"insecure_skip_verify": {
+				Type:        schema.TypeBool,
+				Description: "Set this to true if concourse uses a custom certificate",
+				Optional:    true,
+			},
 			"team": {
 				Type:        schema.TypeString,
 				DefaultFunc: schema.EnvDefaultFunc("FLY_TEAM", nil),


### PR DESCRIPTION
This PR enables to use the provider from behind a proxy which then uses a custom certificate. Now one can add either the proxy certificates to the newly introduced provider config _**ca_cert_file**_ or can set to ignore certificate invalid error using the config variable _**insecure_skip_verify**_