### PR TITLE
release workflow: don't mark releases as drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*'
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          draft: true
     outputs:
       release_upload_url: ${{ steps.create-release.outputs.upload_url }}
 


### PR DESCRIPTION
This seems to work well enough now that we can not worry too much about manual approval.

Also require a `.` in a tag name to trigger a release.