### PR TITLE
ci workflow: trigger on pull_request too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
GitHub should be clever enough to not expose secrets for external pull
request runs.

Good idea?