### PR TITLE
Use TypeSet instead of TypeList for team roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: unit-tests
+        run: make unit-tests
+
       - name: ensure-containers-exist
         env:
           CONCOURSE_VERSION: ${{ matrix.concourse-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
+      - name: unit-tests
+        run: make unit-tests
+
       - name: ensure-containers-exist
         env:
           CONCOURSE_VERSION: ${{ matrix.concourse-version }}

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,7 @@ keys/web/authorized_worker_keys: keys/worker/worker_key
 .PHONY: integration-tests
 integration-tests: keys/web/session_signing_key keys/web/tsa_host_key keys/worker/worker_key keys/worker/tsa_host_key.pub keys/web/authorized_worker_keys
 	go test -count 1 -v ./integration
+
+.PHONY: unit-tests
+unit-tests:
+	go test -count 1 -v ./pkg/provider

--- a/pkg/provider/team_migrate.go
+++ b/pkg/provider/team_migrate.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceTeamResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+
+			"team_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"owners": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				DefaultFunc: func() (interface{}, error) {
+					return make([]string, 0), nil
+				},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"members": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				DefaultFunc: func() (interface{}, error) {
+					return make([]string, 0), nil
+				},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"pipeline_operators": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				DefaultFunc: func() (interface{}, error) {
+					return make([]string, 0), nil
+				},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"viewers": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				DefaultFunc: func() (interface{}, error) {
+					return make([]string, 0), nil
+				},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceTeamStateUpgradeV0(
+	_ context.Context,
+	rawState map[string]interface{},
+	meta interface{},
+) (map[string]interface{}, error) {
+	isNotDigit := func(c rune) bool { return c < '0' || c > '9' }
+
+	rawStateOut := map[string]interface{}{}
+
+	for k, v := range rawState {
+		splitKey := strings.Split(k, ".")
+		if len(splitKey) == 2 && strings.IndexFunc(splitKey[1], isNotDigit) == -1 {
+			switch splitKey[0] {
+				case
+					"owners",
+					"members",
+					"pipeline_operators",
+					"viewers":
+					rawStateOut[fmt.Sprintf("%s.%d", splitKey[0], schema.HashString(v))] = v
+					continue
+			}
+		}
+		rawStateOut[k] = v
+	}
+	return rawStateOut, nil
+}

--- a/pkg/provider/team_migrate_test.go
+++ b/pkg/provider/team_migrate_test.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func getTeamStateDataV0() map[string]interface{} {
+	return map[string]interface{}{
+		"team_name": "foo123",
+		"owners.#": "3",
+		"owners.0": "bar",
+		"owners.1": "baz",
+		"owners.2": "qux",
+		"pipeline_operators.#": "2",
+		"pipeline_operators.0": "abc",
+		"pipeline_operators.1": "def",
+	}
+}
+
+func getTeamStateDataV1() map[string]interface{} {
+	return map[string]interface{}{
+		"team_name": "foo123",
+		"owners.#": "3",
+		"owners.1996459178": "bar",
+		"owners.2015626392": "baz",
+		"owners.2800005064": "qux",
+		"pipeline_operators.#": "2",
+		"pipeline_operators.891568578": "abc",
+		"pipeline_operators.214229345": "def",
+	}
+}
+
+func TestTeamStateUpgradeV0(t *testing.T) {
+	expected := getTeamStateDataV1()
+	actual, err := resourceTeamStateUpgradeV0(nil, getTeamStateDataV0(), nil)
+
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}


### PR DESCRIPTION
https://trello.com/c/TEDpbM7v

This should prevent the provider continually trying to reorder team memberships for no reason.

Now includes a statefile migration, so this _should_ update smoothly.

Add first unit tests (as opposed to integration tests) to cover this.