### PR TITLE
Enable debugging output for go-concourse client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         concourse-version:
           - "6.5.1"
           - "6.7.0"
+          - "7.0.0"
     steps:
       - name: setup
         uses: actions/setup-go@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         concourse-version:
           - "6.5.1"
           - "6.7.0"
+          - "7.0.0"
     steps:
       - name: setup
         uses: actions/setup-go@v2

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -8,6 +10,8 @@ import (
 )
 
 func main() {
+	log.SetPrefix("[DEBUG] ")
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
 			return provider.Provider()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,5 +32,5 @@ func NewConcourseClient(
 	tokenSource := oauth2.StaticTokenSource(tok)
 	httpClient := oauth2.NewClient(ctx, tokenSource)
 
-	return concourse.NewClient(url, httpClient, false), nil
+	return concourse.NewClient(url, httpClient, true), nil
 }


### PR DESCRIPTION
Prefixing output with `[DEBUG]` should cause terraform to appropriately filter for display.

Also add concourse 7.0.0 to the ci matrix