### PR TITLE
Add `concourse_teams` data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ provider "concourse" {
 }
 ```
 
+## Look up all teams
+
+```hcl
+data "concourse_teams" "teams" {
+}
+
+output "team_names" {
+  value = concourse_teams.teams.names
+}
+```
+
 ## Look up a team
 
 ```hcl

--- a/integration/team_mgmt.go
+++ b/integration/team_mgmt.go
@@ -19,6 +19,28 @@ var _ = Describe("Team management", func() {
 	BeforeEach(SetupTest)
 	AfterEach(TeardownTest)
 
+	It("should read all teams", func() {
+		providers := map[string]*schema.Provider{
+			"concourse": provider.Provider(),
+		}
+
+		resource.Test(NewGinkoTerraformTestingT(), resource.TestCase{
+			IsUnitTest: false,
+
+			Providers: providers,
+
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: `data "concourse_teams" "teams" {}`,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.concourse_teams.teams", "names.#", "1"),
+						resource.TestCheckResourceAttr("data.concourse_teams.teams", "names.0", "main"),
+					),
+				},
+			},
+		})
+	})
+
 	It("should manage the lifecycle of a team", func() {
 		providers := map[string]*schema.Provider{
 			"concourse": provider.Provider(),

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -44,6 +44,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"concourse_pipeline": dataPipeline(),
 			"concourse_team":     dataTeam(),
+			"concourse_teams":    dataTeams(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/pkg/provider/teams.go
+++ b/pkg/provider/teams.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataTeams() *schema.Resource {
+	return &schema.Resource{
+		Read: dataTeamsReads,
+		Schema: map[string]*schema.Schema{
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataTeamsReads(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ProviderConfig).Client
+	teams, err := client.ListTeams()
+	if err != nil {
+		return err
+	}
+
+	var names []string
+
+	for _, team := range teams {
+		names = append(names, team.Name)
+	}
+
+	d.SetId("concourse_teams")
+	if err := d.Set("names", names); err != nil {
+		return fmt.Errorf("error setting team names: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Similar to data sources like `aws_security_groups`, allows callers to
retrieve the list of all teams in Concourse. This can be helpful when
the teams themselves are not owned by Terraform, but you need to create
related cloud resources for each team.