### PR TITLE
feat: Adds interface to import pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
           docker-compose up -d && docker-compose down
 
       - name: integration-tests
+        env:
+          CONCOURSE_VERSION: ${{ matrix.concourse-version }}
         run: |
-          sudo make integration-tests-prep-keys
+          sudo -E make integration-tests-prep-keys
           make integration-tests

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ARCH = $$(go env GOARCH)
 
 GENERATE_KEY := \
 		docker run --rm -v $$PWD/keys:/keys --user $$(id -u):$$(id -g) \
-		concourse/concourse:6.5 \
+		concourse/concourse:$${CONCOURSE_VERSION:-6.5.1} \
 		generate-key
 
 # shouldn't use CGO on binaries produced for the terraform registry

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,3 +155,17 @@ resource "concourse_pipeline" "my_pipeline" {
   pipeline_config_format = "json"
 }
 ```
+
+## Import
+
+Concourse teams can be imported using the team name e.g.
+
+```
+ $ terraform import concourse_pipeline.my_team my-team
+```
+
+Concourse pipelines can be imported using the team name and pipeline name e.g.
+
+```
+ $ terraform import concourse_pipeline.my_app my-team:my-app
+```

--- a/integration/pipeline_mgmt.go
+++ b/integration/pipeline_mgmt.go
@@ -136,6 +136,14 @@ jobs:
 				},
 
 				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
+				},
+
+				resource.TestStep{
 					// Pause and expose the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -198,6 +206,14 @@ jobs:
 							return nil
 						},
 					),
+				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
 				resource.TestStep{
@@ -266,6 +282,14 @@ jobs:
 				},
 
 				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
+				},
+
+				resource.TestStep{
 					// Update the pipeline configuration
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -328,6 +352,14 @@ jobs:
 							return nil
 						},
 					),
+				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
 				resource.TestStep{
@@ -396,6 +428,14 @@ jobs:
 				},
 
 				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
+				},
+
+				resource.TestStep{
 					// Rename the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -458,6 +498,14 @@ jobs:
 							return nil
 						},
 					),
+				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
 				resource.TestStep{

--- a/integration/team_mgmt.go
+++ b/integration/team_mgmt.go
@@ -104,6 +104,13 @@ var _ = Describe("Team management", func() {
 				},
 
 				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_team.a_team",
+					ImportStateVerify: true,
+				},
+
+				resource.TestStep{
 					// Add another user as another owner
 
 					Config: `resource "concourse_team" "a_team" {
@@ -156,6 +163,13 @@ var _ = Describe("Team management", func() {
 							return nil
 						},
 					),
+				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_team.a_team",
+					ImportStateVerify: true,
 				},
 
 				resource.TestStep{
@@ -218,6 +232,13 @@ var _ = Describe("Team management", func() {
 				},
 
 				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_team.a_team",
+					ImportStateVerify: true,
+				},
+
+				resource.TestStep{
 					// Removing a user, adding a group
 
 					Config: `resource "concourse_team" "a_team" {
@@ -273,6 +294,13 @@ var _ = Describe("Team management", func() {
 				},
 
 				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_team.a_team",
+					ImportStateVerify: true,
+				},
+
+				resource.TestStep{
 					// New team
 
 					Config: `resource "concourse_team" "new_team" {
@@ -319,6 +347,14 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_team.new_team",
+					ImportStateVerify: true,
+				},
+
 				resource.TestStep{
 					// Rename the team
 
@@ -365,6 +401,13 @@ var _ = Describe("Team management", func() {
 							return nil
 						},
 					),
+				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState: true,
+					ResourceName: "concourse_team.a_team",
+					ImportStateVerify: true,
 				},
 
 				resource.TestStep{

--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -60,6 +60,18 @@ func resourcePipeline() *schema.Resource {
 		UpdateContext: resourcePipelineUpdate,
 		DeleteContext: resourcePipelineDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: func(context context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				teamName, pipelineName, err := parsePipelineID(d.Id())
+				if err != nil {
+					return []*schema.ResourceData{d}, err
+				}
+				d.Set("team_name", teamName)
+				d.Set("pipeline_name", pipelineName)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"pipeline_name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -118,6 +130,13 @@ func pipelineID(teamName string, pipelineName string) string {
 	return fmt.Sprintf("%s:%s", teamName, pipelineName)
 }
 
+func parsePipelineID(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected team_name:pipeline_name", id)
+	}
+	return parts[0], parts[1], nil
+}
 
 func readPipeline(
 	ctx context.Context,

--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -1,17 +1,19 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/concourse/concourse/go-concourse/concourse"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataPipeline() *schema.Resource {
 	return &schema.Resource{
-		Read: dataPipelineRead,
+		ReadContext: dataPipelineRead,
 
 		Schema: map[string]*schema.Schema{
 			"pipeline_name": &schema.Schema{
@@ -53,10 +55,10 @@ func dataPipeline() *schema.Resource {
 
 func resourcePipeline() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePipelineCreate,
-		Read:   resourcePipelineRead,
-		Update: resourcePipelineUpdate,
-		Delete: resourcePipelineDelete,
+		CreateContext: resourcePipelineCreate,
+		ReadContext:   resourcePipelineRead,
+		UpdateContext: resourcePipelineUpdate,
+		DeleteContext: resourcePipelineDelete,
 
 		Schema: map[string]*schema.Schema{
 			"pipeline_name": &schema.Schema{
@@ -116,7 +118,9 @@ func pipelineID(teamName string, pipelineName string) string {
 	return fmt.Sprintf("%s:%s", teamName, pipelineName)
 }
 
+
 func readPipeline(
+	ctx context.Context,
 	client concourse.Client,
 	teamName string,
 	pipelineName string,
@@ -186,15 +190,15 @@ func readPipeline(
 	return retVal, true, nil
 }
 
-func dataPipelineRead(d *schema.ResourceData, m interface{}) error {
+func dataPipelineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	pipelineName := d.Get("pipeline_name").(string)
 	teamName := d.Get("team_name").(string)
 
-	pipeline, wasFound, err := readPipeline(client, teamName, pipelineName)
+	pipeline, wasFound, err := readPipeline(ctx, client, teamName, pipelineName)
 
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error reading pipeline %s from team '%s': %s",
 			pipelineName, teamName, err,
 		)
@@ -213,19 +217,19 @@ func dataPipelineRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourcePipelineCreate(d *schema.ResourceData, m interface{}) error {
-	return resourcePipelineUpdate(d, m)
+func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourcePipelineUpdate(ctx, d, m)
 }
 
-func resourcePipelineRead(d *schema.ResourceData, m interface{}) error {
+func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	pipelineName := d.Get("pipeline_name").(string)
 	teamName := d.Get("team_name").(string)
 
-	pipeline, wasFound, err := readPipeline(client, teamName, pipelineName)
+	pipeline, wasFound, err := readPipeline(ctx, client, teamName, pipelineName)
 
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error reading pipeline %s from team '%s': %s",
 			pipelineName, teamName, err,
 		)
@@ -244,7 +248,7 @@ func resourcePipelineRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
+func resourcePipelineUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 
 	if d.HasChange("team_name") && d.Id() != "" {
@@ -258,7 +262,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		_, err := team.DeletePipeline(oldPipelineName)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error deleting old pipeline %s in team %s: %s",
 				oldPipelineName, oldTeamName, err,
 			)
@@ -275,7 +279,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		_, warnings, err := team.RenamePipeline(oldPipelineName, newPipelineName)
 
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error renaming pipeline %s to %s in team %s: %s %s",
 				oldPipelineName, newPipelineName, teamName, err, SerializeWarnings(warnings),
 			)
@@ -290,10 +294,10 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	pipelineConfig := d.Get("pipeline_config").(string)
 	pipelineConfigFormat := d.Get("pipeline_config_format").(string)
 
-	pipeline, _, err := readPipeline(client, teamName, pipelineName)
+	pipeline, _, err := readPipeline(ctx, client, teamName, pipelineName)
 
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Error looking up pipeline %s in team %s: %s",
 			pipelineName, teamName, err,
 		)
@@ -302,7 +306,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	parsedJSON, err := ParsePipelineConfig(pipelineConfig, pipelineConfigFormat)
 
 	if err != nil {
-		return fmt.Errorf("Error parsing pipeline_config: %s", err)
+		return diag.Errorf("Error parsing pipeline_config: %s", err)
 	}
 
 	_, _, configWarnings, err := team.CreateOrUpdatePipelineConfig(
@@ -310,7 +314,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Encountered error setting config for pipeline %s in team '%s': %s",
 			pipelineName, teamName, err,
 		)
@@ -322,7 +326,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 			warnings += fmt.Sprintf("%s: %s\n", w.Type, w.Message)
 		}
 
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Encountered pipeline warnings (%s/%s):\n %s",
 			pipelineName, teamName, warnings,
 		)
@@ -331,13 +335,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	if d.Get("is_exposed").(bool) {
 		found, err := team.ExposePipeline(pipelineName)
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error exposing pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
@@ -345,13 +349,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	} else {
 		found, err := team.HidePipeline(pipelineName)
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error hiding pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
@@ -361,13 +365,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	if d.Get("is_paused").(bool) {
 		found, err := team.PausePipeline(pipelineName)
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error pausing pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
@@ -375,23 +379,23 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	} else {
 		found, err := team.UnpausePipeline(pipelineName)
 		if err != nil {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Error unpausing pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
-			return fmt.Errorf(
+			return diag.Errorf(
 				"Could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 	}
 
-	return resourcePipelineRead(d, m)
+	return resourcePipelineRead(ctx, d, m)
 }
 
-func resourcePipelineDelete(d *schema.ResourceData, m interface{}) error {
+func resourcePipelineDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	pipelineName := d.Get("pipeline_name").(string)
 	teamName := d.Get("team_name").(string)
@@ -400,14 +404,14 @@ func resourcePipelineDelete(d *schema.ResourceData, m interface{}) error {
 	deleted, err := team.DeletePipeline(pipelineName)
 
 	if err != nil {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Could not delete pipeline %s from team %s: %s",
 			pipelineName, teamName, err,
 		)
 	}
 
 	if !deleted {
-		return fmt.Errorf(
+		return diag.Errorf(
 			"Could not delete pipeline %s from team %s", pipelineName, teamName,
 		)
 	}

--- a/pkg/provider/team.go
+++ b/pkg/provider/team.go
@@ -1,11 +1,12 @@
 package provider
 
 import (
-	"fmt"
+	"context"
 	"strings"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/go-concourse/concourse"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -23,7 +24,7 @@ var roleTypes = []string{
 
 func dataTeam() *schema.Resource {
 	return &schema.Resource{
-		Read: dataTeamRead,
+		ReadContext: dataTeamRead,
 
 		Schema: map[string]*schema.Schema{
 			"team_name": &schema.Schema{
@@ -72,10 +73,10 @@ func dataTeam() *schema.Resource {
 
 func resourceTeam() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceTeamCreate,
-		Read:   resourceTeamRead,
-		Update: resourceTeamUpdate,
-		Delete: resourceTeamDelete,
+		CreateContext: resourceTeamCreate,
+		ReadContext:   resourceTeamRead,
+		UpdateContext: resourceTeamUpdate,
+		DeleteContext: resourceTeamDelete,
 
 		Schema: map[string]*schema.Schema{
 
@@ -166,9 +167,10 @@ func (t *teamHelper) appendElem(field string, elem string) {
 }
 
 func readTeam(
+	ctx context.Context,
 	client concourse.Client,
 	teamName string,
-) (teamHelper, error) {
+) (teamHelper, diag.Diagnostics) {
 
 	retVal := teamHelper{
 		TeamName: teamName,
@@ -177,7 +179,7 @@ func readTeam(
 	teams, err := client.ListTeams()
 
 	if err != nil {
-		return retVal, err
+		return retVal, diag.FromErr(err)
 	}
 
 	var foundTeam *atc.Team
@@ -190,7 +192,7 @@ func readTeam(
 	}
 
 	if foundTeam == nil {
-		return retVal, fmt.Errorf("Could not find team %s", teamName)
+		return retVal, diag.Errorf("Could not find team %s", teamName)
 	}
 
 	var (
@@ -222,11 +224,11 @@ func readTeam(
 	return retVal, nil
 }
 
-func dataTeamRead(d *schema.ResourceData, m interface{}) error {
+func dataTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	teamName := d.Get("team_name").(string)
 
-	team, err := readTeam(client, teamName)
+	team, err := readTeam(ctx, client, teamName)
 
 	if err != nil {
 		return err
@@ -240,19 +242,19 @@ func dataTeamRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourceTeamCreate(d *schema.ResourceData, m interface{}) error {
-	return resourceTeamCreateUpdate(d, m, true)
+func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceTeamCreateUpdate(ctx, d, m, true)
 }
 
-func resourceTeamUpdate(d *schema.ResourceData, m interface{}) error {
-	return resourceTeamCreateUpdate(d, m, false)
+func resourceTeamUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceTeamCreateUpdate(ctx, d, m, false)
 }
 
-func resourceTeamRead(d *schema.ResourceData, m interface{}) error {
+func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	teamName := d.Get("team_name").(string)
 
-	team, err := readTeam(client, teamName)
+	team, err := readTeam(ctx, client, teamName)
 
 	if err != nil {
 		return err
@@ -266,7 +268,7 @@ func resourceTeamRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourceTeamCreateUpdate(d *schema.ResourceData, m interface{}, create bool) error {
+func resourceTeamCreateUpdate(ctx context.Context, d *schema.ResourceData, m interface{}, create bool) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	teamName := d.Get("team_name").(string)
 	auths := make(map[string][]string)
@@ -317,29 +319,29 @@ func resourceTeamCreateUpdate(d *schema.ResourceData, m interface{}, create bool
 		_, warnings, err := team.RenameTeam(d.Id(), d.Get("team_name").(string))
 
 		if err != nil {
-			return fmt.Errorf("Could not rename team %s %s", teamName, SerializeWarnings(warnings))
+			return diag.Errorf("Could not rename team %s %s", teamName, SerializeWarnings(warnings))
 		}
 	}
 
 	_, created, updated, warnings, err := team.CreateOrUpdate(teamDetails)
 
 	if err != nil {
-		return fmt.Errorf("Error creating/updating team %s: %s %s", teamName, err, SerializeWarnings(warnings))
+		return diag.Errorf("Error creating/updating team %s: %s %s", teamName, err, SerializeWarnings(warnings))
 	}
 
 	if !created && !updated {
-		return fmt.Errorf("Could not create or update team %s", teamName)
+		return diag.Errorf("Could not create or update team %s", teamName)
 	}
 
-	return resourceTeamRead(d, m)
+	return resourceTeamRead(ctx, d, m)
 }
 
-func resourceTeamDelete(d *schema.ResourceData, m interface{}) error {
+func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	teamName := d.Get("team_name").(string)
 
 	if teamName == "main" {
-		return fmt.Errorf("Cannot delete main team")
+		return diag.Errorf("Cannot delete main team")
 	}
 
 	team := client.Team(teamName)
@@ -347,7 +349,7 @@ func resourceTeamDelete(d *schema.ResourceData, m interface{}) error {
 	err := team.DestroyTeam(teamName)
 
 	if err != nil {
-		return fmt.Errorf("Could not delete team %s: %s", teamName, err)
+		return diag.Errorf("Could not delete team %s: %s", teamName, err)
 	}
 
 	d.SetId("")

--- a/pkg/provider/team.go
+++ b/pkg/provider/team.go
@@ -77,6 +77,12 @@ func resourceTeam() *schema.Resource {
 		ReadContext:   resourceTeamRead,
 		UpdateContext: resourceTeamUpdate,
 		DeleteContext: resourceTeamDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: func(context context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("team_name", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 

--- a/pkg/provider/teams.go
+++ b/pkg/provider/teams.go
@@ -1,14 +1,15 @@
 package provider
 
 import (
-	"fmt"
+	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataTeams() *schema.Resource {
 	return &schema.Resource{
-		Read: dataTeamsReads,
+		ReadContext: dataTeamsReads,
 		Schema: map[string]*schema.Schema{
 			"names": {
 				Type:     schema.TypeSet,
@@ -19,11 +20,11 @@ func dataTeams() *schema.Resource {
 	}
 }
 
-func dataTeamsReads(d *schema.ResourceData, m interface{}) error {
+func dataTeamsReads(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
 	teams, err := client.ListTeams()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	var names []string
@@ -34,7 +35,7 @@ func dataTeamsReads(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId("concourse_teams")
 	if err := d.Set("names", names); err != nil {
-		return fmt.Errorf("error setting team names: %s", err)
+		return diag.Errorf("error setting team names: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
I would like to be able to import pipelines/teams. I don't write a lot of Go code nor do I know a lot about the internals of Concourse, so this might not be useful for a number of reasons.

Let me know if there is anything I can do to help land this in the upstream.