### PR TITLE
Style fixes

### DIFF
--- a/integration/pipeline_mgmt_test.go
+++ b/integration/pipeline_mgmt_test.go
@@ -134,16 +134,14 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
-
-				resource.TestStep{
+				{
 					// Pause and expose the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -207,16 +205,14 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
-
-				resource.TestStep{
+				{
 					// Unpause and hide the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -280,16 +276,14 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
-
-				resource.TestStep{
+				{
 					// Update the pipeline configuration
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -353,16 +347,14 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
-
-				resource.TestStep{
+				{
 					// Move a pipeline from one team to another
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -426,16 +418,14 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
-
-				resource.TestStep{
+				{
 					// Rename the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -499,16 +489,14 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
-
-				resource.TestStep{
+				{
 					// Delete the pipeline
 
 					Config: `data "concourse_team" "main_team" {

--- a/integration/pipeline_mgmt_test.go
+++ b/integration/pipeline_mgmt_test.go
@@ -70,7 +70,7 @@ jobs:
 			Providers: providers,
 
 			Steps: []resource.TestStep{
-				resource.TestStep{
+				{
 					// Add a pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -134,8 +134,7 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Pause and expose the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -199,8 +198,7 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Unpause and hide the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -264,8 +262,7 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Update the pipeline configuration
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -329,8 +326,7 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Move a pipeline from one team to another
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -394,8 +390,7 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Rename the pipeline
 
 					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
@@ -459,8 +454,7 @@ jobs:
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Delete the pipeline
 
 					Config: `data "concourse_team" "main_team" {

--- a/integration/team_mgmt_test.go
+++ b/integration/team_mgmt_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/alphagov/terraform-provider-concourse/pkg/provider"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/concourse/concourse/atc"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -30,7 +30,7 @@ var _ = Describe("Team management", func() {
 			Providers: providers,
 
 			Steps: []resource.TestStep{
-				resource.TestStep{
+				{
 					Config: `data "concourse_teams" "teams" {}`,
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("data.concourse_teams.teams", "names.#", "1"),
@@ -56,7 +56,7 @@ var _ = Describe("Team management", func() {
 			Providers: providers,
 
 			Steps: []resource.TestStep{
-				resource.TestStep{
+				{
 					// Add a user as an owner
 
 					Config: `resource "concourse_team" "a_team" {
@@ -102,8 +102,7 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Add another user as another owner
 
 					Config: `resource "concourse_team" "a_team" {
@@ -157,8 +156,7 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Change a user from an owner to a pipeline-operator
 
 					Config: `resource "concourse_team" "a_team" {
@@ -199,14 +197,14 @@ var _ = Describe("Team management", func() {
 
 							expectedTeamAuth := atc.TeamAuth{
 								"pipeline-operator": {
-								  "users": {
-								    "github:tlwr",
-								  },
+									"users": {
+										"github:tlwr",
+									},
 								},
 								"owner": {
-								  "users": {
-								    "github:terraform-provider-concourse",
-								  },
+									"users": {
+										"github:terraform-provider-concourse",
+									},
 								},
 							}
 
@@ -216,8 +214,7 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Removing a user, adding a group
 
 					Config: `resource "concourse_team" "a_team" {
@@ -260,8 +257,8 @@ var _ = Describe("Team management", func() {
 
 							expectedTeamAuth := atc.TeamAuth{
 								"owner": {
-								  "users": {"github:terraform-provider-concourse"},
-								  "groups": {"github:alphagov:paas-team"},
+									"users":  {"github:terraform-provider-concourse"},
+									"groups": {"github:alphagov:paas-team"},
 								},
 							}
 
@@ -271,8 +268,7 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// New team
 
 					Config: `resource "concourse_team" "new_team" {
@@ -319,7 +315,7 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-				resource.TestStep{
+				{
 					// Rename the team
 
 					Config: `resource "concourse_team" "a_team" {
@@ -366,8 +362,7 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// Delete the team
 
 					Config: `# Cannot be empty`,

--- a/integration/team_mgmt_test.go
+++ b/integration/team_mgmt_test.go
@@ -102,15 +102,13 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_team.a_team",
+					ImportState:       true,
+					ResourceName:      "concourse_team.a_team",
 					ImportStateVerify: true,
 				},
-
-				resource.TestStep{
+				{
 					// Add another user as another owner
 
 					Config: `resource "concourse_team" "a_team" {
@@ -164,15 +162,13 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_team.a_team",
+					ImportState:       true,
+					ResourceName:      "concourse_team.a_team",
 					ImportStateVerify: true,
 				},
-
-				resource.TestStep{
+				{
 					// Change a user from an owner to a pipeline-operator
 
 					Config: `resource "concourse_team" "a_team" {
@@ -230,15 +226,13 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_team.a_team",
+					ImportState:       true,
+					ResourceName:      "concourse_team.a_team",
 					ImportStateVerify: true,
 				},
-
-				resource.TestStep{
+				{
 					// Removing a user, adding a group
 
 					Config: `resource "concourse_team" "a_team" {
@@ -292,15 +286,13 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_team.a_team",
+					ImportState:       true,
+					ResourceName:      "concourse_team.a_team",
 					ImportStateVerify: true,
 				},
-
-				resource.TestStep{
+				{
 					// New team
 
 					Config: `resource "concourse_team" "new_team" {
@@ -347,15 +339,13 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_team.new_team",
+					ImportState:       true,
+					ResourceName:      "concourse_team.new_team",
 					ImportStateVerify: true,
 				},
-
-				resource.TestStep{
+				{
 					// Rename the team
 
 					Config: `resource "concourse_team" "a_team" {
@@ -402,15 +392,13 @@ var _ = Describe("Team management", func() {
 						},
 					),
 				},
-
-				resource.TestStep{
+				{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_team.a_team",
+					ImportState:       true,
+					ResourceName:      "concourse_team.a_team",
 					ImportStateVerify: true,
 				},
-
-				resource.TestStep{
+				{
 					// Delete the team
 
 					Config: `# Cannot be empty`,

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/alphagov/terraform-provider-concourse/pkg/provider"
 )

--- a/pkg/provider/config.go
+++ b/pkg/provider/config.go
@@ -24,7 +24,7 @@ func ProviderConfigurationBuilder(
 		target, err := rc.LoadTarget(targetName, false)
 
 		if err != nil {
-			return nil, fmt.Errorf("Error loading target: %s", err)
+			return nil, fmt.Errorf("error loading target: %s", err)
 		}
 
 		return &ProviderConfig{
@@ -45,7 +45,7 @@ func ProviderConfigurationBuilder(
 		)
 
 		if err != nil {
-			return nil, fmt.Errorf("Error creating client: %s", err)
+			return nil, fmt.Errorf("error creating client: %s", err)
 		}
 
 		return &ProviderConfig{
@@ -54,6 +54,6 @@ func ProviderConfigurationBuilder(
 	}
 
 	return nil, fmt.Errorf(
-		`Please specify "target" or "username", "password", "team", and "url"`,
+		`please specify "target" or "username", "password", "team", and "url"`,
 	)
 }

--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -14,35 +14,30 @@ func dataPipeline() *schema.Resource {
 		Read: dataPipelineRead,
 
 		Schema: map[string]*schema.Schema{
-			"pipeline_name": &schema.Schema{
+			"pipeline_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"team_name": &schema.Schema{
+			"team_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"is_exposed": &schema.Schema{
+			"is_exposed": {
 				Type:     schema.TypeBool,
 				Required: false,
 				Computed: true,
 			},
-
-			"is_paused": &schema.Schema{
+			"is_paused": {
 				Type:     schema.TypeBool,
 				Required: false,
 				Computed: true,
 			},
-
-			"yaml": &schema.Schema{
+			"yaml": {
 				Type:     schema.TypeString,
 				Required: false,
 				Computed: true,
 			},
-
-			"json": &schema.Schema{
+			"json": {
 				Type:     schema.TypeString,
 				Required: false,
 				Computed: true,
@@ -59,42 +54,35 @@ func resourcePipeline() *schema.Resource {
 		Delete: resourcePipelineDelete,
 
 		Schema: map[string]*schema.Schema{
-			"pipeline_name": &schema.Schema{
+			"pipeline_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"team_name": &schema.Schema{
+			"team_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"is_exposed": &schema.Schema{
+			"is_exposed": {
 				Type:     schema.TypeBool,
 				Required: true,
 			},
-
-			"is_paused": &schema.Schema{
+			"is_paused": {
 				Type:     schema.TypeBool,
 				Required: true,
 			},
-
-			"pipeline_config_format": &schema.Schema{
+			"pipeline_config_format": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"pipeline_config": &schema.Schema{
+			"pipeline_config": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"json": &schema.Schema{
+			"json": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"yaml": &schema.Schema{
+			"yaml": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -146,7 +134,7 @@ func readPipeline(
 
 	if err != nil {
 		return retVal, false, fmt.Errorf(
-			"Error looking up pipeline %s within team '%s': %s",
+			"error looking up pipeline %s within team '%s': %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -163,7 +151,7 @@ func readPipeline(
 	pipelineCfgJSON, err := JSONToJSON(string(pipelineCfg))
 	if err != nil {
 		return retVal, false, fmt.Errorf(
-			"Encountered error parsing pipeline %s config within team '%s': %s",
+			"encountered error parsing pipeline %s config within team '%s': %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -172,7 +160,7 @@ func readPipeline(
 
 	if err != nil {
 		return retVal, false, fmt.Errorf(
-			"Encountered error parsing pipeline %s config within team '%s': %s",
+			"encountered error parsing pipeline %s config within team '%s': %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -195,7 +183,7 @@ func dataPipelineRead(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf(
-			"Error reading pipeline %s from team '%s': %s",
+			"error reading pipeline %s from team '%s': %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -226,7 +214,7 @@ func resourcePipelineRead(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf(
-			"Error reading pipeline %s from team '%s': %s",
+			"error reading pipeline %s from team '%s': %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -259,7 +247,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 
 		if err != nil {
 			return fmt.Errorf(
-				"Error deleting old pipeline %s in team %s: %s",
+				"error deleting old pipeline %s in team %s: %s",
 				oldPipelineName, oldTeamName, err,
 			)
 		}
@@ -276,7 +264,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 
 		if err != nil {
 			return fmt.Errorf(
-				"Error renaming pipeline %s to %s in team %s: %s %s",
+				"error renaming pipeline %s to %s in team %s: %s %s",
 				oldPipelineName, newPipelineName, teamName, err, SerializeWarnings(warnings),
 			)
 		}
@@ -294,7 +282,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf(
-			"Error looking up pipeline %s in team %s: %s",
+			"error looking up pipeline %s in team %s: %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -302,7 +290,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 	parsedJSON, err := ParsePipelineConfig(pipelineConfig, pipelineConfigFormat)
 
 	if err != nil {
-		return fmt.Errorf("Error parsing pipeline_config: %s", err)
+		return fmt.Errorf("error parsing pipeline_config: %s", err)
 	}
 
 	_, _, configWarnings, err := team.CreateOrUpdatePipelineConfig(
@@ -311,7 +299,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf(
-			"Encountered error setting config for pipeline %s in team '%s': %s",
+			"encountered error setting config for pipeline %s in team '%s': %s",
 			pipelineName, teamName, err,
 		)
 	}
@@ -323,7 +311,7 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		return fmt.Errorf(
-			"Encountered pipeline warnings (%s/%s):\n %s",
+			"encountered pipeline warnings (%s/%s):\n %s",
 			pipelineName, teamName, warnings,
 		)
 	}
@@ -332,13 +320,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		found, err := team.ExposePipeline(pipelineName)
 		if err != nil {
 			return fmt.Errorf(
-				"Error exposing pipeline %s in team '%s': %s",
+				"error exposing pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
 			return fmt.Errorf(
-				"Could not find pipeline %s in team '%s': %s",
+				"could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
@@ -346,13 +334,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		found, err := team.HidePipeline(pipelineName)
 		if err != nil {
 			return fmt.Errorf(
-				"Error hiding pipeline %s in team '%s': %s",
+				"error hiding pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
 			return fmt.Errorf(
-				"Could not find pipeline %s in team '%s': %s",
+				"could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
@@ -362,13 +350,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		found, err := team.PausePipeline(pipelineName)
 		if err != nil {
 			return fmt.Errorf(
-				"Error pausing pipeline %s in team '%s': %s",
+				"error pausing pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
 			return fmt.Errorf(
-				"Could not find pipeline %s in team '%s': %s",
+				"could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
@@ -376,13 +364,13 @@ func resourcePipelineUpdate(d *schema.ResourceData, m interface{}) error {
 		found, err := team.UnpausePipeline(pipelineName)
 		if err != nil {
 			return fmt.Errorf(
-				"Error unpausing pipeline %s in team '%s': %s",
+				"error unpausing pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
 		if !found {
 			return fmt.Errorf(
-				"Could not find pipeline %s in team '%s': %s",
+				"could not find pipeline %s in team '%s': %s",
 				pipelineName, teamName, err,
 			)
 		}
@@ -401,14 +389,14 @@ func resourcePipelineDelete(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf(
-			"Could not delete pipeline %s from team %s: %s",
+			"could not delete pipeline %s from team %s: %s",
 			pipelineName, teamName, err,
 		)
 	}
 
 	if !deleted {
 		return fmt.Errorf(
-			"Could not delete pipeline %s from team %s", pipelineName, teamName,
+			"could not delete pipeline %s from team %s", pipelineName, teamName,
 		)
 	}
 

--- a/pkg/provider/team.go
+++ b/pkg/provider/team.go
@@ -26,12 +26,11 @@ func dataTeam() *schema.Resource {
 		Read: dataTeamRead,
 
 		Schema: map[string]*schema.Schema{
-			"team_name": &schema.Schema{
+			"team_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"owners": &schema.Schema{
+			"owners": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Set:      schema.HashString,
@@ -39,8 +38,7 @@ func dataTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"members": &schema.Schema{
+			"members": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Set:      schema.HashString,
@@ -48,8 +46,7 @@ func dataTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"pipeline_operators": &schema.Schema{
+			"pipeline_operators": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Set:      schema.HashString,
@@ -57,8 +54,7 @@ func dataTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"viewers": &schema.Schema{
+			"viewers": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Set:      schema.HashString,
@@ -78,13 +74,11 @@ func resourceTeam() *schema.Resource {
 		Delete: resourceTeamDelete,
 
 		Schema: map[string]*schema.Schema{
-
-			"team_name": &schema.Schema{
+			"team_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"owners": &schema.Schema{
+			"owners": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Set:      schema.HashString,
@@ -95,8 +89,7 @@ func resourceTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"members": &schema.Schema{
+			"members": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Set:      schema.HashString,
@@ -107,8 +100,7 @@ func resourceTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"pipeline_operators": &schema.Schema{
+			"pipeline_operators": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Set:      schema.HashString,
@@ -119,8 +111,7 @@ func resourceTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"viewers": &schema.Schema{
+			"viewers": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Set:      schema.HashString,
@@ -136,7 +127,7 @@ func resourceTeam() *schema.Resource {
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type: resourceTeamResourceV0().CoreConfigSchema().ImpliedType(),
+				Type:    resourceTeamResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: resourceTeamStateUpgradeV0,
 				Version: 0,
 			},
@@ -190,7 +181,7 @@ func readTeam(
 	}
 
 	if foundTeam == nil {
-		return retVal, fmt.Errorf("Could not find team %s", teamName)
+		return retVal, fmt.Errorf("could not find team %s", teamName)
 	}
 
 	var (
@@ -300,7 +291,7 @@ func resourceTeamCreateUpdate(d *schema.ResourceData, m interface{}, create bool
 	// we cant set a role into the TeamAuth struct if it doesnt exist
 	// otherwise sending the atc.Team to concourse creates "role": null entries
 	for _, role := range roleNames {
-		if roleEnabled[role] == true {
+		if roleEnabled[role] {
 			teamDetails.Auth[role] = map[string][]string{}
 			for _, roleType := range roleTypes {
 				roleValues := auths[role+"_"+roleType]
@@ -317,18 +308,18 @@ func resourceTeamCreateUpdate(d *schema.ResourceData, m interface{}, create bool
 		_, warnings, err := team.RenameTeam(d.Id(), d.Get("team_name").(string))
 
 		if err != nil {
-			return fmt.Errorf("Could not rename team %s %s", teamName, SerializeWarnings(warnings))
+			return fmt.Errorf("could not rename team %s %s", teamName, SerializeWarnings(warnings))
 		}
 	}
 
 	_, created, updated, warnings, err := team.CreateOrUpdate(teamDetails)
 
 	if err != nil {
-		return fmt.Errorf("Error creating/updating team %s: %s %s", teamName, err, SerializeWarnings(warnings))
+		return fmt.Errorf("error creating/updating team %s: %s %s", teamName, err, SerializeWarnings(warnings))
 	}
 
 	if !created && !updated {
-		return fmt.Errorf("Could not create or update team %s", teamName)
+		return fmt.Errorf("could not create or update team %s", teamName)
 	}
 
 	return resourceTeamRead(d, m)
@@ -339,7 +330,7 @@ func resourceTeamDelete(d *schema.ResourceData, m interface{}) error {
 	teamName := d.Get("team_name").(string)
 
 	if teamName == "main" {
-		return fmt.Errorf("Cannot delete main team")
+		return fmt.Errorf("cannot delete main team")
 	}
 
 	team := client.Team(teamName)
@@ -347,7 +338,7 @@ func resourceTeamDelete(d *schema.ResourceData, m interface{}) error {
 	err := team.DestroyTeam(teamName)
 
 	if err != nil {
-		return fmt.Errorf("Could not delete team %s: %s", teamName, err)
+		return fmt.Errorf("could not delete team %s: %s", teamName, err)
 	}
 
 	d.SetId("")

--- a/pkg/provider/team_migrate.go
+++ b/pkg/provider/team_migrate.go
@@ -11,13 +11,11 @@ import (
 func resourceTeamResourceV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-
-			"team_name": &schema.Schema{
+			"team_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"owners": &schema.Schema{
+			"owners": {
 				Type:     schema.TypeList,
 				Required: true,
 				DefaultFunc: func() (interface{}, error) {
@@ -27,8 +25,7 @@ func resourceTeamResourceV0() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"members": &schema.Schema{
+			"members": {
 				Type:     schema.TypeList,
 				Optional: true,
 				DefaultFunc: func() (interface{}, error) {
@@ -38,8 +35,7 @@ func resourceTeamResourceV0() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"pipeline_operators": &schema.Schema{
+			"pipeline_operators": {
 				Type:     schema.TypeList,
 				Optional: true,
 				DefaultFunc: func() (interface{}, error) {
@@ -49,8 +45,7 @@ func resourceTeamResourceV0() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-
-			"viewers": &schema.Schema{
+			"viewers": {
 				Type:     schema.TypeList,
 				Optional: true,
 				DefaultFunc: func() (interface{}, error) {
@@ -77,13 +72,13 @@ func resourceTeamStateUpgradeV0(
 		splitKey := strings.Split(k, ".")
 		if len(splitKey) == 2 && strings.IndexFunc(splitKey[1], isNotDigit) == -1 {
 			switch splitKey[0] {
-				case
-					"owners",
-					"members",
-					"pipeline_operators",
-					"viewers":
-					rawStateOut[fmt.Sprintf("%s.%d", splitKey[0], schema.HashString(v))] = v
-					continue
+			case
+				"owners",
+				"members",
+				"pipeline_operators",
+				"viewers":
+				rawStateOut[fmt.Sprintf("%s.%d", splitKey[0], schema.HashString(v))] = v
+				continue
 			}
 		}
 		rawStateOut[k] = v

--- a/pkg/provider/team_migrate_test.go
+++ b/pkg/provider/team_migrate_test.go
@@ -1,17 +1,18 @@
 package provider
 
 import (
+	"context"
 	"reflect"
 	"testing"
 )
 
 func getTeamStateDataV0() map[string]interface{} {
 	return map[string]interface{}{
-		"team_name": "foo123",
-		"owners.#": "3",
-		"owners.0": "bar",
-		"owners.1": "baz",
-		"owners.2": "qux",
+		"team_name":            "foo123",
+		"owners.#":             "3",
+		"owners.0":             "bar",
+		"owners.1":             "baz",
+		"owners.2":             "qux",
 		"pipeline_operators.#": "2",
 		"pipeline_operators.0": "abc",
 		"pipeline_operators.1": "def",
@@ -20,12 +21,12 @@ func getTeamStateDataV0() map[string]interface{} {
 
 func getTeamStateDataV1() map[string]interface{} {
 	return map[string]interface{}{
-		"team_name": "foo123",
-		"owners.#": "3",
-		"owners.1996459178": "bar",
-		"owners.2015626392": "baz",
-		"owners.2800005064": "qux",
-		"pipeline_operators.#": "2",
+		"team_name":                    "foo123",
+		"owners.#":                     "3",
+		"owners.1996459178":            "bar",
+		"owners.2015626392":            "baz",
+		"owners.2800005064":            "qux",
+		"pipeline_operators.#":         "2",
 		"pipeline_operators.891568578": "abc",
 		"pipeline_operators.214229345": "def",
 	}
@@ -33,7 +34,7 @@ func getTeamStateDataV1() map[string]interface{} {
 
 func TestTeamStateUpgradeV0(t *testing.T) {
 	expected := getTeamStateDataV1()
-	actual, err := resourceTeamStateUpgradeV0(nil, getTeamStateDataV0(), nil)
+	actual, err := resourceTeamStateUpgradeV0(context.Background(), getTeamStateDataV0(), nil)
 
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)


### PR DESCRIPTION
While working on https://github.com/alphagov/terraform-provider-concourse/pull/42 I noticed a number of linter complaints that presumably began appearing after the recent bump to go1.18. This PR fixes these, most commonly:

- Error messages starting with capital letters
- Redundant type definitions that are inferred by enclosing collection definitions
- a `nil` context

This also moves all integration test files into the `_test` scope.