### PR TITLE
Refactor: Use ID-only read and import

### DIFF
--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -61,15 +61,7 @@ func resourcePipeline() *schema.Resource {
 		DeleteContext: resourcePipelineDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(context context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				teamName, pipelineName, err := parsePipelineID(d.Id())
-				if err != nil {
-					return []*schema.ResourceData{d}, err
-				}
-				d.Set("team_name", teamName)
-				d.Set("pipeline_name", pipelineName)
-				return []*schema.ResourceData{d}, nil
-			},
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -242,8 +234,10 @@ func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*ProviderConfig).Client
-	pipelineName := d.Get("pipeline_name").(string)
-	teamName := d.Get("team_name").(string)
+	teamName, pipelineName, err := parsePipelineID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	pipeline, wasFound, err := readPipeline(ctx, client, teamName, pipelineName)
 
@@ -255,7 +249,9 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	if wasFound {
-		d.SetId(pipelineID(teamName, pipelineName))
+		d.SetId(pipelineID(pipeline.TeamName, pipeline.PipelineName))
+		d.Set("team_name", pipeline.TeamName)
+		d.Set("pipeline_name", pipeline.PipelineName)
 		d.Set("is_exposed", pipeline.IsExposed)
 		d.Set("is_paused", pipeline.IsPaused)
 		d.Set("json", pipeline.JSON)


### PR DESCRIPTION
According to the [import section of the tutorial for custom providers](https://developer.hashicorp.com/terraform/tutorials/providers/provider-import?in=terraform%2Fproviders#implement-import), the preferred way to implement an import is via a resource read function which can perform a read using _only_ the resource ID:

> ```go
> func resourceOrder() *schema.Resource {
>   return &schema.Resource{
>     # ..
>     Schema: map[string]*schema.Schema{
>       # ..
>     },
>     Importer: &schema.ResourceImporter{
>        StateContext: schema.ImportStatePassthroughContext,
>     },
>   }
> }
> ```
>
>Terraform passes the `order_id `value to the read function (`resourceOrderRead`), which then populates the resource's (`hashicups_order.sample`) state. **This is the preferred method but requires a Read function that can retrieve the entire resource state using `d.Id()` only.**
>
> _Tip: This import method highlights the importance of selecting a descriptive and unique resource ID. A good resource ID can retrieve the resource state via API. In some cases, you can construct an ID from multiple attributes (for example, `<region>:<resource_id>`)._

emphasis mine.
