### PR TITLE
use findTeam instead of listTeams in readTeam

### DIFF
--- a/pkg/provider/team.go
+++ b/pkg/provider/team.go
@@ -143,7 +143,7 @@ func resourceTeam() *schema.Resource {
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type: resourceTeamResourceV0().CoreConfigSchema().ImpliedType(),
+				Type:    resourceTeamResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: resourceTeamStateUpgradeV0,
 				Version: 0,
 			},
@@ -178,26 +178,17 @@ func readTeam(
 	teamName string,
 ) (teamHelper, diag.Diagnostics) {
 
+	team, err := client.FindTeam(teamName)
+
 	retVal := teamHelper{
 		TeamName: teamName,
 	}
-
-	teams, err := client.ListTeams()
 
 	if err != nil {
 		return retVal, diag.FromErr(err)
 	}
 
-	var foundTeam *atc.Team
-
-	for _, team := range teams {
-		if team.Name == teamName {
-			foundTeam = &team
-			break
-		}
-	}
-
-	if foundTeam == nil {
+	if team == nil {
 		return retVal, diag.Errorf("Could not find team %s", teamName)
 	}
 
@@ -207,7 +198,7 @@ func readTeam(
 	)
 
 	for _, roleName := range roleNames {
-		if role, ok = foundTeam.Auth[roleName]; !ok {
+		if role, ok = team.Auth()[roleName]; !ok {
 			continue
 		}
 


### PR DESCRIPTION
Rather than listing all the teams with `listTeams` we can use `findTeam` instead. Integration tests still pass.