### PR TITLE
support fly templating with variables

### DIFF
--- a/integration/pipeline_mgmt.go
+++ b/integration/pipeline_mgmt.go
@@ -156,9 +156,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState:             true,
-					ResourceName:            "concourse_pipeline.a_pipeline",
-					ImportStateVerify:       true,
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -229,9 +229,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState:             true,
-					ResourceName:            "concourse_pipeline.a_pipeline",
-					ImportStateVerify:       true,
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -302,9 +302,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState:             true,
-					ResourceName:            "concourse_pipeline.a_pipeline",
-					ImportStateVerify:       true,
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -451,9 +451,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState:             true,
-					ResourceName:            "concourse_pipeline.a_pipeline",
-					ImportStateVerify:       true,
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -524,9 +524,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState:             true,
-					ResourceName:            "concourse_pipeline.a_pipeline",
-					ImportStateVerify:       true,
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -597,9 +597,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState:             true,
-					ResourceName:            "concourse_pipeline.a_pipeline",
-					ImportStateVerify:       true,
+					ImportState: true,
+					ResourceName: "concourse_pipeline.a_pipeline",
+					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 

--- a/integration/pipeline_mgmt.go
+++ b/integration/pipeline_mgmt.go
@@ -54,6 +54,8 @@ jobs:
       trigger: true
 `
 
+		templatedPipelineConfigJSON = `{"jobs":[{"name":"check-the-time","plan":[{"get":"every-midnight","trigger":true}],"serial":true}],"resources":[{"name":"every-midnight","source":{"location":"Europe/Berlin","start":"12:00AM","stop":"12:15AM"},"type":"time"}]}`
+
 		updatedPipelineConfig = `#
 resources:
   - name: every-midnight
@@ -154,9 +156,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -227,9 +229,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -300,9 +302,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -330,7 +332,7 @@ jobs:
 %s
                       PIPELINE
 					  vars = {
-						location = "Europe/London"
+						location = "Europe/Berlin"
 					  }
                    }`, templatedPipelineConfig),
 
@@ -346,7 +348,7 @@ jobs:
 						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "team_name", "main"),
 						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "is_exposed", "false"),
 						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "is_paused", "false"),
-						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "json", pipelineConfigJSON),
+						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "json", templatedPipelineConfigJSON),
 
 						func(s *terraform.State) error {
 							teams, err := client.ListTeams()
@@ -449,9 +451,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -522,9 +524,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 
@@ -595,9 +597,9 @@ jobs:
 
 				resource.TestStep{
 					// check this state is importable
-					ImportState: true,
-					ResourceName: "concourse_pipeline.a_pipeline",
-					ImportStateVerify: true,
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
 				},
 

--- a/integration/pipeline_mgmt.go
+++ b/integration/pipeline_mgmt.go
@@ -37,6 +37,23 @@ jobs:
 
 		pipelineConfigJSON = `{"jobs":[{"name":"check-the-time","plan":[{"get":"every-midnight","trigger":true}],"serial":true}],"resources":[{"name":"every-midnight","source":{"location":"Europe/London","start":"12:00AM","stop":"12:15AM"},"type":"time"}]}`
 
+		templatedPipelineConfig = `#
+resources:
+  - name: every-midnight
+    type: time
+    source:
+      location: ((location))
+      start: 12:00AM
+      stop: 12:15AM
+
+jobs:
+  - name: check-the-time
+    serial: true
+    plan:
+    - get: every-midnight
+      trigger: true
+`
+
 		updatedPipelineConfig = `#
 resources:
   - name: every-midnight
@@ -287,6 +304,82 @@ jobs:
 					ResourceName: "concourse_pipeline.a_pipeline",
 					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format"},
+				},
+
+				resource.TestStep{
+					// Add variables to the configuration
+
+					Config: fmt.Sprintf(`data "concourse_team" "main_team" {
+					 team_name = "main"
+                   }
+
+                   resource "concourse_team" "other_team" {
+					 team_name = "other"
+					 owners = ["user:github:tlwr"]
+                   }
+
+                   resource "concourse_pipeline" "a_pipeline" {
+                      team_name     = "${data.concourse_team.main_team.team_name}"
+                      pipeline_name = "pipeline-a"
+
+                      is_exposed = false
+                      is_paused  = false
+
+                      pipeline_config_format = "yaml"
+                      pipeline_config        = <<PIPELINE
+%s
+                      PIPELINE
+					  vars = {
+						location = "Europe/London"
+					  }
+                   }`, templatedPipelineConfig),
+
+					Check: resource.ComposeTestCheckFunc(
+						func(s *terraform.State) error {
+							By("Updating the pipeline configuration with a template and variables")
+
+							fmt.Printf("%+v\n", s)
+							return nil
+						},
+
+						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "pipeline_name", "pipeline-a"),
+						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "team_name", "main"),
+						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "is_exposed", "false"),
+						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "is_paused", "false"),
+						resource.TestCheckResourceAttr("concourse_pipeline.a_pipeline", "json", pipelineConfigJSON),
+
+						func(s *terraform.State) error {
+							teams, err := client.ListTeams()
+
+							if err != nil {
+								return err
+							}
+
+							Expect(teams).To(HaveLen(2))
+
+							Expect(teams[0].Name).To(Equal("main"))
+							Expect(teams[1].Name).To(Equal("other"))
+
+							pipelines, err := client.ListPipelines()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(pipelines).To(HaveLen(1))
+
+							Expect(pipelines[0].Name).To(Equal("pipeline-a"))
+							Expect(pipelines[0].TeamName).To(Equal("main"))
+							Expect(pipelines[0].Paused).To(Equal(false))
+							Expect(pipelines[0].Public).To(Equal(false))
+
+							return nil
+						},
+					),
+				},
+
+				resource.TestStep{
+					// check this state is importable
+					ImportState:             true,
+					ResourceName:            "concourse_pipeline.a_pipeline",
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"pipeline_config", "pipeline_config_format", "vars"},
 				},
 
 				resource.TestStep{

--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -103,7 +103,7 @@ func resourcePipeline() *schema.Resource {
 				Required: true,
 			},
 
-			"vars": {
+			"vars": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 			},

--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -103,6 +103,11 @@ func resourcePipeline() *schema.Resource {
 				Required: true,
 			},
 
+			"vars": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+
 			"json": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -312,6 +317,7 @@ func resourcePipelineUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	pipelineConfig := d.Get("pipeline_config").(string)
 	pipelineConfigFormat := d.Get("pipeline_config_format").(string)
+	vars := d.Get("vars").(map[string]interface{})
 
 	pipeline, _, err := readPipeline(ctx, client, teamName, pipelineName)
 
@@ -322,7 +328,7 @@ func resourcePipelineUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		)
 	}
 
-	parsedJSON, err := ParsePipelineConfig(pipelineConfig, pipelineConfigFormat)
+	parsedJSON, err := ParsePipelineConfig(pipelineConfig, pipelineConfigFormat, vars)
 
 	if err != nil {
 		return diag.Errorf("Error parsing pipeline_config: %s", err)


### PR DESCRIPTION
Closes #34.

Add a new `vars` parameter to the `concourse_pipeline` resource.
When not `nil`, the `parsePipelineConfig` function now calls the templating functions used by the `fly set-pipeline` command.

Here is where `fly set-pipeline` does templating:
https://github.com/concourse/concourse/blob/cfe7746ae74247743708be6c5b2f40215030a1f1/fly/commands/set_pipeline.go#L85-L86
Here are the helpers it is calling (where we can see that the first argument to `Resolve` is always `false`):
https://github.com/concourse/concourse/blob/cfe7746ae74247743708be6c5b2f40215030a1f1/fly/commands/internal/templatehelpers/yaml_template.go
and here is where fly's API client always calls that function with `allowEmpty: false`, so `Resolve` is always called with `false, false`:
https://github.com/concourse/concourse/blob/cfe7746ae74247743708be6c5b2f40215030a1f1/fly/commands/internal/setpipelinehelpers/atc_config.go#L45

I have also added an integration test for pipeline management where the location is templated in the pipeline config and the variable is passed as a parameter on the resource. The test then checks that the pipeline JSON is identical to the non-templated version.

However, there aren't any integration tests for a variable _not_ being given a value (which is allowed in concourse)