### PR TITLE
use ValidateDiagFunc for pipeline_config_format

### DIFF
--- a/pkg/provider/pipeline.go
+++ b/pkg/provider/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataPipeline() *schema.Resource {
@@ -94,8 +95,9 @@ func resourcePipeline() *schema.Resource {
 			},
 
 			"pipeline_config_format": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"json", "yaml"}, false)),
 			},
 
 			"pipeline_config": &schema.Schema{

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -52,10 +52,6 @@ func ParsePipelineConfig(
 	pipelineConfig string,
 	pipelineConfigFormat string,
 ) (string, error) {
-	if pipelineConfigFormat != "json" && pipelineConfigFormat != "yaml" {
-		return "", fmt.Errorf("pipeline_config_format must be json or yaml")
-	}
-
 	var err error
 	outputJSON := ""
 


### PR DESCRIPTION
We don't need the custom validation logic for `"pipeline_config_format"`.
We can use [ValidateDiagFunc](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors#validatediagfunc) with helpers from the [helpers/validation package in the SDK](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation).