### PR TITLE
Reuse CI workflow for release, enable CI on `pull_request`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
-on: [push]
+on:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   pull_request:
+  workflow_call:
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,38 +7,9 @@ on:
 
 jobs:
 
-  test:  # this is cloned from ci.yml until github actions support job reuse
+  test:
     if: ${{ github.repository_owner == 'terraform-provider-concourse' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        concourse-version:
-          - "6.5.1"
-          - "6.7.0"
-          - "7.0.0"
-          - "7.8.2"
-    steps:
-      - name: setup
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
-
-      - name: checkout
-        uses: actions/checkout@v1
-
-      - name: unit-tests
-        run: make unit-tests
-
-      - name: ensure-containers-exist
-        env:
-          CONCOURSE_VERSION: ${{ matrix.concourse-version }}
-        run: |
-          docker-compose up -d && docker-compose down
-
-      - name: integration-tests
-        run: |
-          sudo make integration-tests-prep-keys
-          make integration-tests
+    uses: ./.github/workflows/ci.yml
 
   get-tag-name:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Running CI on `pull_request` should be fine as long as we have the repo configured to require approval for every run.

It also means external contributors can get CI run on their PRs without a repo owner doing some branch trickery (which needs to be re-done every time another PR is merged as github isn't clever enough to detect merge commits being equivalents of the PR HEAD.

Also, take advantage of new-ish support for workflow reuse and remove some pipeline copy-pasta.