### PR TITLE
docs: include pipeline `vars` feature in examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,10 @@ resource "concourse_pipeline" "my_pipeline" {
 
   pipeline_config        = file("pipeline-config.yml")
   pipeline_config_format = "yaml"
+
+  vars = {
+    foo = "bar"
+  }
 }
 
 # OR
@@ -153,6 +157,10 @@ resource "concourse_pipeline" "my_pipeline" {
 
   pipeline_config        = file("pipeline-config.json")
   pipeline_config_format = "json"
+
+  vars = {
+    foo = "bar"
+  }
 }
 ```
 


### PR DESCRIPTION
Mention feature added in  #50.

At some point we should consider turning this into _proper_ documentation, with descriptions of all arguments.