### PR TITLE
Release windows versions of provider

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [ "test", "get-tag-name" ]
     strategy:
       matrix:
-        goos: [ "linux", "darwin" ]
+        goos: [ "linux", "darwin", "windows" ]
         goarch: [ "amd64", "arm64" ]
     steps:
       - name: setup


### PR DESCRIPTION
I would like to use this provider on a windows machine.

The binary compiles successfully with `GOOS=windows` however I have not thoroughly tested it.